### PR TITLE
Set an explicit value to is_create_org

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Also, see the SDKs section in Kinde’s [contributing guidelines](https://githu
 Run the following command to generate the SDK:
 
 ```bash
-openapi-generator-cli generate -i https://kinde.com/api/kinde-mgmt-api-specs.yaml -g csharp -o Kinde.Sdk --package-name=Kinde.Api -c config.yaml --library=httpclient --additional-properties=targetFramework=net6.0,packageVersion=1.2.5,sourceFolder=
+openapi-generator-cli generate -i https://kinde.com/api/kinde-mgmt-api-specs.yaml -g csharp -o Kinde.Sdk --package-name=Kinde.Api -c config.yaml --library=httpclient --additional-properties=targetFramework=net6.0,packageVersion=1.2.6,sourceFolder=
 ```
 
 **Note:** The API specifications should always point to Kinde's hosted version: https://kinde.com/api/kinde-mgmt-api-specs.yaml. This is set via the ` -i` option in the [OpenAPI Generator CLI](https://openapi-generator.tech/docs/usage/), for example:

--- a/my_custom_templates/Kinde.Api/Flows/BaseAuthorizationFlow.cs
+++ b/my_custom_templates/Kinde.Api/Flows/BaseAuthorizationFlow.cs
@@ -34,9 +34,14 @@ namespace Kinde.Api.Flows
             var parameters = new Dictionary<string, string>
             {
                 { "client_id", Configuration.ClientId },
-                { "scope", Configuration.Scope },
-                { "is_create_org", Configuration.IsCreateOrganization.ToString()}
+                { "scope", Configuration.Scope }
             };
+
+            if (Configuration.IsCreateOrganization)
+            {
+                parameters.Add("is_create_org", "true");
+            }
+
             if (!string.IsNullOrEmpty(Configuration.Audience))
             {
                 parameters.Add("audience", Configuration.Audience);


### PR DESCRIPTION
# Explain your changes

This was was being sent through as `True`, for consistency and explicitly set it to `true` and only when required.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved handling of organization creation settings in the authorization flow.
- **Documentation**
	- Updated version number in OpenAPI Generator CLI command for SDK generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->