### PR TITLE
Back port changes to target .NET standard 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Also, see the SDKs section in Kinde’s [contributing guidelines](https://githu
 Run the following command to generate the SDK:
 
 ```bash
-openapi-generator-cli generate -i https://api-spec.kinde.com/kinde-combined-api-specs.yaml -g csharp -o Kinde.Sdk --package-name=Kinde.Api -c config.yaml --library=httpclient --additional-properties=targetFramework=net6.0,packageVersion=1.2.11,sourceFolder=
+openapi-generator-cli generate -i https://api-spec.kinde.com/kinde-combined-api-specs.yaml -g csharp -o Kinde.Sdk --package-name=Kinde.Api -c config.yaml --library=httpclient --additional-properties=targetFramework=netstandard2.1,packageVersion=1.3.0,sourceFolder=
 ```
 
 **Note:** The API specifications should always point to Kinde's hosted version: https://api-spec.kinde.com/kinde-combined-api-specs.yaml. This is set via the ` -i` option in the [OpenAPI Generator CLI](https://openapi-generator.tech/docs/usage/), for example:

--- a/config.yaml
+++ b/config.yaml
@@ -28,6 +28,8 @@ files:
     destinationFilename: ./Kinde.Api/Hashing/ICodeVerifier.cs
   Kinde.Api/Hashing/SHA256CodeVerifier.cs:
     destinationFilename: ./Kinde.Api/Hashing/SHA256CodeVerifier.cs
+  Kinde.Api/IsExternalInit.cs:
+    destinationFilename: ./Kinde.Api/IsExternalInit.cs
   Kinde.Api/KindeClient.cs:
     destinationFilename: ./Kinde.Api/KindeClient.cs
   Kinde.Api/KindeClientFactory.cs:

--- a/my_custom_templates/Kinde.Api/IsExternalInit.cs
+++ b/my_custom_templates/Kinde.Api/IsExternalInit.cs
@@ -1,0 +1,7 @@
+namespace System.Runtime.CompilerServices
+{
+    using System.ComponentModel;
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit {}
+}

--- a/my_custom_templates/Kinde.Api/KindeHttpClient.cs
+++ b/my_custom_templates/Kinde.Api/KindeHttpClient.cs
@@ -31,14 +31,5 @@ namespace Kinde.Api
 
             return base.SendAsync(request, cancellationToken);
         }
-
-        public override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            request.Headers.TryAddWithoutValidation("cache-control", "no-cache");
-            request.Headers.TryAddWithoutValidation("User-Agent", "PostmanRuntime/7.29.2");
-            if (Token != null) request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + Token.AccessToken);
-
-            return base.Send(request, cancellationToken);
-        }
     }
 }

--- a/my_custom_templates/netcore_project.mustache
+++ b/my_custom_templates/netcore_project.mustache
@@ -26,6 +26,7 @@
     <GenerateDocumentationFile>False</GenerateDocumentationFile>
     <IncludeSymbols>True</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -58,14 +59,14 @@
       {{/supportsRetry}}
       {{/useGenericHost}}
       {{#supportsRetry}}
-    <PackageReference Include="Polly" Version="{{^netStandard}}7.2.3{{/netStandard}}{{#netStandard}}7.2.3{{/netStandard}}" />
+    <PackageReference Include="Polly" Version="{{^netStandard}}7.2.3{{/netStandard}}{{#netStandard}}8.5.2{{/netStandard}}" />
       {{/supportsRetry}}
     {{#validatable}}
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     {{/validatable}}
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.8.0" />
   </ItemGroup>
 
 {{>netcore_project.additions}}</Project>


### PR DESCRIPTION
# Explain your changes

Back port the changes from https://github.com/kinde-oss/kinde-dotnet-sdk/pull/23 to target .NET standard 2.1

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
